### PR TITLE
date time on user side at input date working differently on chrome and firefox issue fixed(issues/255)

### DIFF
--- a/frontend/src/components/v4/ActionInputs/InputDate.vue
+++ b/frontend/src/components/v4/ActionInputs/InputDate.vue
@@ -22,7 +22,7 @@
 				<b-row>
 					<b-col cols="12" sm="12" md="12">
 						<div class="follow">
-							<b-form-input type="datetime-local" :placeholder="data.placeHolder" v-model="data.value" :disabled="done" :required="data.isManadatory"></b-form-input>
+							<b-form-input type="date" :placeholder="data.placeHolder" v-model="data.value" :disabled="done" :required="data.isManadatory"></b-form-input>
 						</div>
 					</b-col>
 				</b-row>


### PR DESCRIPTION
1. datetime-local is not supported in firefox but it supports in chrome.

2. date is supported in both browser

